### PR TITLE
Change pkg/client.Client to an interface

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
         unstash 'source'
         insideGo{
           dir("${BASE_DIR}"){
-            sh(label: 'Unit test', script: 'go test ./... 2>&1 | tee test_results.txt')
+            sh(label: 'Unit test', script: 'go test -race ./... 2>&1 | tee test_results.txt')
             sh(label: 'Convert test results', script: 'go-junit-report < test_results.txt > junit.xml')
           }
         }

--- a/.ci/jenkins-go-agent/Dockerfile
+++ b/.ci/jenkins-go-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.2
+FROM golang:1.14.4
 
 RUN \
     apt-get -qq -y update \

--- a/.ci/jenkins-go-agent/Dockerfile
+++ b/.ci/jenkins-go-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.4
+FROM golang:1.13.12
 
 RUN \
     apt-get -qq -y update \

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -86,7 +86,7 @@ type Client interface {
 	Status(status proto.StateObserved_Status, message string)
 }
 
-// Client manages the state and communication to the Elastic Agent.
+// client manages the state and communication to the Elastic Agent.
 type client struct {
 	target          string
 	opts            []grpc.DialOption

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -90,7 +90,7 @@ func TestClient_Checkin_With_Token(t *testing.T) {
 
 	// connect with an valid token
 	impl = &StubClientImpl{}
-	validClient := New(fmt.Sprintf(":%d", srv.Port), token, impl, nil, grpc.WithInsecure())
+	validClient := New(fmt.Sprintf(":%d", srv.Port), token, impl, nil, grpc.WithInsecure()).(*client)
 	require.NoError(t, validClient.Start(context.Background()))
 	defer validClient.Stop()
 	require.NoError(t, waitFor(func() error {
@@ -157,7 +157,7 @@ func TestClient_Checkin_Status(t *testing.T) {
 	defer srv.Stop()
 
 	impl := &StubClientImpl{}
-	client := New(fmt.Sprintf(":%d", srv.Port), token, impl, nil, grpc.WithInsecure())
+	client := New(fmt.Sprintf(":%d", srv.Port), token, impl, nil, grpc.WithInsecure()).(*client)
 	client.minCheckTimeout = 100 * time.Millisecond
 	require.NoError(t, client.Start(context.Background()))
 	defer client.Stop()
@@ -238,7 +238,7 @@ func TestClient_Checkin_Stop(t *testing.T) {
 	defer srv.Stop()
 
 	impl := &StubClientImpl{}
-	client := New(fmt.Sprintf(":%d", srv.Port), token, impl, nil, grpc.WithInsecure())
+	client := New(fmt.Sprintf(":%d", srv.Port), token, impl, nil, grpc.WithInsecure()).(*client)
 	client.minCheckTimeout = 100 * time.Millisecond
 	require.NoError(t, client.Start(context.Background()))
 	defer client.Stop()

--- a/pkg/client/reader.go
+++ b/pkg/client/reader.go
@@ -18,7 +18,7 @@ import (
 )
 
 // NewFromReader creates a new client reading the connection information from the io.Reader.
-func NewFromReader(reader io.Reader, impl StateInterface, actions ...Action) (*Client, error) {
+func NewFromReader(reader io.Reader, impl StateInterface, actions ...Action) (Client, error) {
 	connInfo := &proto.ConnInfo{}
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {


### PR DESCRIPTION
Changes `New` and `NewFromReader` to return `Client` as an interface instead of a struct. This will allow others to mock the client in tests or other situations where it might be required.