### PR TITLE
Move the stub servers to an exportable package

### DIFF
--- a/pkg/client/artifact_test.go
+++ b/pkg/client/artifact_test.go
@@ -9,26 +9,28 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 )
 
 func TestArtifact(t *testing.T) {
-	token := newID()
-	srv := StubServerV2{
+	token := mock.NewID()
+	srv := mock.StubServerV2{
 		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
 			if observed.Token == token {
 				return &proto.CheckinExpected{
 					Units: []*proto.UnitExpected{
 						{
-							Id:             newID(),
+							Id:             mock.NewID(),
 							Type:           proto.UnitType_OUTPUT,
 							State:          proto.State_HEALTHY,
 							ConfigStateIdx: 1,
@@ -91,8 +93,8 @@ func TestArtifact(t *testing.T) {
 	artifactClient := unit.Artifacts()
 
 	t.Run("ErrorOnFetch", func(t *testing.T) {
-		id := newID()
-		badID := newID()
+		id := mock.NewID()
+		badID := mock.NewID()
 		srv.ArtifactFetchImpl = func(request *proto.ArtifactFetchRequest, server proto.ElasticAgentArtifact_FetchServer) error {
 			if request.Id != id || request.Sha256 != id {
 				return errors.New("missing artifact")
@@ -105,7 +107,7 @@ func TestArtifact(t *testing.T) {
 	})
 
 	t.Run("Fetch", func(t *testing.T) {
-		id := newID()
+		id := mock.NewID()
 		content := make([]byte, 256)
 		_, err := rand.Read(content)
 		require.NoError(t, err)

--- a/pkg/client/log_test.go
+++ b/pkg/client/log_test.go
@@ -7,26 +7,28 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 )
 
 func TestLog(t *testing.T) {
-	token := newID()
-	srv := StubServerV2{
+	token := mock.NewID()
+	srv := mock.StubServerV2{
 		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
 			if observed.Token == token {
 				return &proto.CheckinExpected{
 					Units: []*proto.UnitExpected{
 						{
-							Id:             newID(),
+							Id:             mock.NewID(),
 							Type:           proto.UnitType_OUTPUT,
 							State:          proto.State_HEALTHY,
 							ConfigStateIdx: 1,

--- a/pkg/client/mock/helpers.go
+++ b/pkg/client/mock/helpers.go
@@ -1,0 +1,12 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mock
+
+import "github.com/gofrs/uuid"
+
+// NewID is a small wrapper that returns a UUID used for agent client IDs
+func NewID() string {
+	return uuid.Must(uuid.NewV4()).String()
+}

--- a/pkg/client/mock/stub_serverV1.go
+++ b/pkg/client/mock/stub_serverV1.go
@@ -1,0 +1,179 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/gofrs/uuid"
+	"google.golang.org/grpc"
+)
+
+// StubServerCheckin is used by the StubServer
+type StubServerCheckin func(*proto.StateObserved) *proto.StateExpected
+
+//StubServerAction is used by the StubServer
+type StubServerAction func(*proto.ActionResponse) error
+
+// PerformAction is the stubbed action type for the mocked server
+type PerformAction struct {
+	Name     string
+	Params   []byte
+	Callback func(map[string]interface{}, error)
+	UnitID   string
+	UnitType proto.UnitType
+}
+
+type actionResultCh struct {
+	Result map[string]interface{}
+	Err    error
+}
+
+// StubServer is the type that mocks an elastic agent controller server
+type StubServer struct {
+	proto.UnimplementedElasticAgentServer
+
+	Port        int
+	CheckinImpl StubServerCheckin
+	ActionImpl  StubServerAction
+
+	server      *grpc.Server
+	ActionsChan chan *PerformAction
+	SentActions map[string]*PerformAction
+}
+
+// Start the sub V2 server
+func (s *StubServer) Start(opt ...grpc.ServerOption) error {
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return err
+	}
+	s.Port = lis.Addr().(*net.TCPAddr).Port
+	srv := grpc.NewServer(opt...)
+	s.server = srv
+	proto.RegisterElasticAgentServer(s.server, s)
+	go func() {
+		srv.Serve(lis)
+	}()
+	return nil
+}
+
+// Stop the stub V1 server
+func (s *StubServer) Stop() {
+	if s.server != nil {
+		s.server.Stop()
+		s.server = nil
+	}
+}
+
+// Checkin implementaiton for the stub server
+func (s *StubServer) Checkin(server proto.ElasticAgent_CheckinServer) error {
+	for {
+		checkin, err := server.Recv()
+		if err != nil {
+			return err
+		}
+		resp := s.CheckinImpl(checkin)
+		if resp == nil {
+			// close connection to client
+			return nil
+		}
+		err = server.Send(resp)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// Actions implementation for the stub server
+func (s *StubServer) Actions(server proto.ElasticAgent_ActionsServer) error {
+	var m sync.Mutex
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case act := <-s.ActionsChan:
+				id := uuid.Must(uuid.NewV4())
+				m.Lock()
+				s.SentActions[id.String()] = act
+				m.Unlock()
+				err := server.Send(&proto.ActionRequest{
+					Id:     id.String(),
+					Name:   act.Name,
+					Params: act.Params,
+				})
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	}()
+	defer close(done)
+
+	for {
+		response, err := server.Recv()
+		if err != nil {
+			return err
+		}
+		err = s.ActionImpl(response)
+		if err != nil {
+			// close connection to client
+			return nil
+		}
+		m.Lock()
+		action, ok := s.SentActions[response.Id]
+		if !ok {
+			// nothing to do, unknown action
+			m.Unlock()
+			continue
+		}
+		delete(s.SentActions, response.Id)
+		m.Unlock()
+		var result map[string]interface{}
+		err = json.Unmarshal(response.Result, &result)
+		if err != nil {
+			return err
+		}
+		if response.Status == proto.ActionResponse_FAILED {
+			error, ok := result["error"]
+			if ok {
+				err = fmt.Errorf("%s", error)
+			} else {
+				err = fmt.Errorf("unknown error")
+			}
+			action.Callback(nil, err)
+		} else {
+			action.Callback(result, nil)
+		}
+	}
+}
+
+// PerformAction implementation for the stub server
+func (s *StubServer) PerformAction(name string, params map[string]interface{}) (map[string]interface{}, error) {
+	paramBytes, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resCh := make(chan actionResultCh)
+	s.ActionsChan <- &PerformAction{
+		Name:   name,
+		Params: paramBytes,
+		Callback: func(m map[string]interface{}, err error) {
+			resCh <- actionResultCh{
+				Result: m,
+				Err:    err,
+			}
+		},
+	}
+	res := <-resCh
+	return res.Result, res.Err
+}

--- a/pkg/client/mock/stub_serverV2.go
+++ b/pkg/client/mock/stub_serverV2.go
@@ -1,0 +1,252 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/gofrs/uuid"
+	"google.golang.org/grpc"
+)
+
+// StubServerCheckinV2 is the checkin function for the V2 controller
+type StubServerCheckinV2 func(observed *proto.CheckinObserved) *proto.CheckinExpected
+
+// StubServerArtifactFetch is the artifact fetch function for the V2 controller
+type StubServerArtifactFetch func(request *proto.ArtifactFetchRequest, server proto.ElasticAgentArtifact_FetchServer) error
+
+// StubServerLog is the logging function for the V2 controller
+type StubServerLog func(fetch *proto.LogMessageRequest) (*proto.LogMessageResponse, error)
+
+// StubServerStore is the interface that mocks the server artifact store
+type StubServerStore interface {
+	BeginTx(request *proto.StoreBeginTxRequest) (*proto.StoreBeginTxResponse, error)
+	GetKey(request *proto.StoreGetKeyRequest) (*proto.StoreGetKeyResponse, error)
+	SetKey(request *proto.StoreSetKeyRequest) (*proto.StoreSetKeyResponse, error)
+	DeleteKey(request *proto.StoreDeleteKeyRequest) (*proto.StoreDeleteKeyResponse, error)
+	CommitTx(request *proto.StoreCommitTxRequest) (*proto.StoreCommitTxResponse, error)
+	DiscardTx(request *proto.StoreDiscardTxRequest) (*proto.StoreDiscardTxResponse, error)
+}
+
+// StubServerV2 is the mocked server implementation for the V2 controller
+type StubServerV2 struct {
+	proto.UnimplementedElasticAgentServer
+	proto.UnimplementedElasticAgentStoreServer
+	proto.UnimplementedElasticAgentArtifactServer
+	proto.UnimplementedElasticAgentLogServer
+
+	Port              int
+	CheckinImpl       StubServerCheckin
+	ActionImpl        StubServerAction
+	CheckinV2Impl     StubServerCheckinV2
+	StoreImpl         StubServerStore
+	ArtifactFetchImpl StubServerArtifactFetch
+	LogImpl           StubServerLog
+
+	server      *grpc.Server
+	ActionsChan chan *PerformAction
+	SentActions map[string]*PerformAction
+}
+
+// Start the mock server
+func (s *StubServerV2) Start(opt ...grpc.ServerOption) error {
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return err
+	}
+	s.Port = lis.Addr().(*net.TCPAddr).Port
+	srv := grpc.NewServer(opt...)
+	s.server = srv
+	proto.RegisterElasticAgentServer(s.server, s)
+	proto.RegisterElasticAgentStoreServer(s.server, s)
+	proto.RegisterElasticAgentArtifactServer(s.server, s)
+	proto.RegisterElasticAgentLogServer(s.server, s)
+	go func() {
+		srv.Serve(lis)
+	}()
+	return nil
+}
+
+// Stop the mock server
+func (s *StubServerV2) Stop() {
+	if s.server != nil {
+		s.server.Stop()
+		s.server = nil
+	}
+}
+
+// Checkin is the checkin implementation for the mock server
+func (s *StubServerV2) Checkin(server proto.ElasticAgent_CheckinServer) error {
+	for {
+		checkin, err := server.Recv()
+		if err != nil {
+			return err
+		}
+		resp := s.CheckinImpl(checkin)
+		if resp == nil {
+			// close connection to client
+			return nil
+		}
+		err = server.Send(resp)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// CheckinV2 is the V2 checkin implementation for the mock server
+func (s *StubServerV2) CheckinV2(server proto.ElasticAgent_CheckinV2Server) error {
+	for {
+		checkin, err := server.Recv()
+		if err != nil {
+			return err
+		}
+		resp := s.CheckinV2Impl(checkin)
+		if resp == nil {
+			// close connection to client
+			return nil
+		}
+		err = server.Send(resp)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// Actions is the action implementation for the mock V2 server
+func (s *StubServerV2) Actions(server proto.ElasticAgent_ActionsServer) error {
+	var m sync.Mutex
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case act := <-s.ActionsChan:
+				id := uuid.Must(uuid.NewV4())
+				m.Lock()
+				s.SentActions[id.String()] = act
+				m.Unlock()
+				err := server.Send(&proto.ActionRequest{
+					Id:       id.String(),
+					Name:     act.Name,
+					Params:   act.Params,
+					UnitId:   act.UnitID,
+					UnitType: act.UnitType,
+				})
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	}()
+	defer close(done)
+
+	for {
+		response, err := server.Recv()
+		if err != nil {
+			return err
+		}
+		err = s.ActionImpl(response)
+		if err != nil {
+			// close connection to client
+			return nil
+		}
+		m.Lock()
+		action, ok := s.SentActions[response.Id]
+		if !ok {
+			// nothing to do, unknown action
+			m.Unlock()
+			continue
+		}
+		delete(s.SentActions, response.Id)
+		m.Unlock()
+		var result map[string]interface{}
+		err = json.Unmarshal(response.Result, &result)
+		if err != nil {
+			return err
+		}
+		if response.Status == proto.ActionResponse_FAILED {
+			error, ok := result["error"]
+			if ok {
+				err = fmt.Errorf("%s", error)
+			} else {
+				err = fmt.Errorf("unknown error")
+			}
+			action.Callback(nil, err)
+		} else {
+			action.Callback(result, nil)
+		}
+	}
+}
+
+// PerformAction is the implementation for the V2 mock server
+func (s *StubServerV2) PerformAction(unitID string, unitType proto.UnitType, name string, params map[string]interface{}) (map[string]interface{}, error) {
+	paramBytes, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resCh := make(chan actionResultCh)
+	s.ActionsChan <- &PerformAction{
+		UnitID:   unitID,
+		UnitType: unitType,
+		Name:     name,
+		Params:   paramBytes,
+		Callback: func(m map[string]interface{}, err error) {
+			resCh <- actionResultCh{
+				Result: m,
+				Err:    err,
+			}
+		},
+	}
+	res := <-resCh
+	return res.Result, res.Err
+}
+
+// BeginTx implmenentation for the V2 stub server
+func (s *StubServerV2) BeginTx(_ context.Context, request *proto.StoreBeginTxRequest) (*proto.StoreBeginTxResponse, error) {
+	return s.StoreImpl.BeginTx(request)
+}
+
+// GetKey implmenentation for the V2 stub server
+func (s *StubServerV2) GetKey(_ context.Context, request *proto.StoreGetKeyRequest) (*proto.StoreGetKeyResponse, error) {
+	return s.StoreImpl.GetKey(request)
+}
+
+// SetKey implmenentation for the V2 stub server
+func (s *StubServerV2) SetKey(_ context.Context, request *proto.StoreSetKeyRequest) (*proto.StoreSetKeyResponse, error) {
+	return s.StoreImpl.SetKey(request)
+}
+
+// DeleteKey implmenentation for the V2 stub server
+func (s *StubServerV2) DeleteKey(_ context.Context, request *proto.StoreDeleteKeyRequest) (*proto.StoreDeleteKeyResponse, error) {
+	return s.StoreImpl.DeleteKey(request)
+}
+
+// CommitTx implmenentation for the V2 stub server
+func (s *StubServerV2) CommitTx(_ context.Context, request *proto.StoreCommitTxRequest) (*proto.StoreCommitTxResponse, error) {
+	return s.StoreImpl.CommitTx(request)
+}
+
+// DiscardTx implmenentation for the V2 stub server
+func (s *StubServerV2) DiscardTx(_ context.Context, request *proto.StoreDiscardTxRequest) (*proto.StoreDiscardTxResponse, error) {
+	return s.StoreImpl.DiscardTx(request)
+}
+
+// Fetch implmenentation for the V2 stub server
+func (s *StubServerV2) Fetch(request *proto.ArtifactFetchRequest, server proto.ElasticAgentArtifact_FetchServer) error {
+	return s.ArtifactFetchImpl(request, server)
+}
+
+// Log implmenentation for the V2 stub server
+func (s *StubServerV2) Log(_ context.Context, request *proto.LogMessageRequest) (*proto.LogMessageResponse, error) {
+	return s.LogImpl(request)
+}

--- a/pkg/client/reader_test.go
+++ b/pkg/client/reader_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 )
 
@@ -58,7 +59,7 @@ func TestNewFromReader_Connects(t *testing.T) {
 	var m sync.Mutex
 	token := "expected_token"
 	gotValid := false
-	srv := StubServer{
+	srv := mock.StubServer{
 		CheckinImpl: func(observed *proto.StateObserved) *proto.StateExpected {
 			m.Lock()
 			defer m.Unlock()
@@ -78,7 +79,7 @@ func TestNewFromReader_Connects(t *testing.T) {
 			// actions not tested here
 			return nil
 		},
-		actions: make(chan *performAction, 100),
+		ActionsChan: make(chan *mock.PerformAction, 100),
 	}
 	require.NoError(t, srv.Start(grpc.Creds(creds)))
 	defer srv.Stop()

--- a/pkg/client/store_test.go
+++ b/pkg/client/store_test.go
@@ -16,19 +16,20 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 )
 
 func TestStore(t *testing.T) {
-	token := newID()
+	token := mock.NewID()
 	store := NewMemoryStore()
-	srv := StubServerV2{
+	srv := mock.StubServerV2{
 		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
 			if observed.Token == token {
 				return &proto.CheckinExpected{
 					Units: []*proto.UnitExpected{
 						{
-							Id:             newID(),
+							Id:             mock.NewID(),
 							Type:           proto.UnitType_OUTPUT,
 							State:          proto.State_HEALTHY,
 							ConfigStateIdx: 1,
@@ -252,7 +253,7 @@ type unitMemoryStore struct {
 }
 
 func (s *unitMemoryStore) startTx(writeable bool) string {
-	txID := newID()
+	txID := mock.NewID()
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	data := s.copyData()


### PR DESCRIPTION
This moves all of the "stub" controller servers used by the client tests to their own package, where they can be exported and used elsewhere.

I mainly wanted this for the shipper, since I needed something to test against until the V2 controller is complete.