### PR TITLE
[v2] Add stringer interface to client types.

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -30,6 +30,19 @@ const (
 	UnitChangedRemoved UnitChangedType = 3
 )
 
+// String returns string representation for the unit changed type.
+func (t UnitChangedType) String() string {
+	switch t {
+	case UnitChangedAdded:
+		return "added"
+	case UnitChangedModified:
+		return "modified"
+	case UnitChangedRemoved:
+		return "removed"
+	}
+	return "unknown"
+}
+
 // UnitChanged is what is sent over the UnitChanges channel any time a unit is added, modified, or removed.
 type UnitChanged struct {
 	Type UnitChangedType

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -23,6 +23,17 @@ const (
 	UnitTypeOutput = UnitType(proto.UnitType_OUTPUT)
 )
 
+// String returns string representation for the unit type.
+func (t UnitType) String() string {
+	switch t {
+	case UnitTypeInput:
+		return "input"
+	case UnitTypeOutput:
+		return "output"
+	}
+	return "unknown"
+}
+
 // UnitLogLevel is the log level the unit should run at.
 type UnitLogLevel proto.UnitLogLevel
 
@@ -38,6 +49,23 @@ const (
 	// UnitLogLevelTrace is when the unit should log at trace level.
 	UnitLogLevelTrace = UnitLogLevel(proto.UnitLogLevel_TRACE)
 )
+
+// String returns string representation for the unit log level.
+func (l UnitLogLevel) String() string {
+	switch l {
+	case UnitLogLevelError:
+		return "error"
+	case UnitLogLevelWarn:
+		return "warn"
+	case UnitLogLevelInfo:
+		return "info"
+	case UnitLogLevelDebug:
+		return "debug"
+	case UnitLogLevelTrace:
+		return "trace"
+	}
+	return "unknown"
+}
 
 // UnitState is the state for the unit, used both for expected and observed state.
 type UnitState proto.State
@@ -58,6 +86,27 @@ const (
 	// UnitStateStopped is when the unit is stopped.
 	UnitStateStopped = UnitState(proto.State_STOPPED)
 )
+
+// String returns string representation for the unit state.
+func (l UnitState) String() string {
+	switch l {
+	case UnitStateStarting:
+		return "starting"
+	case UnitStateConfiguring:
+		return "configuring"
+	case UnitStateHealthy:
+		return "healthy"
+	case UnitStateDegraded:
+		return "degraded"
+	case UnitStateFailed:
+		return "failed"
+	case UnitStateStopping:
+		return "stopping"
+	case UnitStateStopped:
+		return "stopped"
+	}
+	return "unknown"
+}
 
 // Unit represents a distinct item that needs to be operating with-in this process.
 //


### PR DESCRIPTION
This is a nice to have for helping with logging. Added to easily take the different types and turn them into strings. Implemented the `Stringer` interface.