### PR TITLE
ci: use fleet-ci

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,10 +1,10 @@
-  
+
 ---
 
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: beats-ci
+    cluster: fleet-ci
 
 ##### JOB DEFAULTS
 

--- a/.ci/jobs/elastic-agent-client.yml
+++ b/.ci/jobs/elastic-agent-client.yml
@@ -3,7 +3,6 @@
     name: Ingest-manager/elastic-agent-client
     display-name: Elastic Agent Client
     description: Jenkins pipeline for the Elastic Agent Client project
-    view: Beats
     project-type: multibranch
     script-path: .ci/Jenkinsfile
     scm:


### PR DESCRIPTION
## What is the problem this PR solves?

Use `fleet-ci`  to scale horizontally the CI.


## Why

In order to distribute the load and reduce a single point of failure,

## Actions

- [ ] Agree when to merge
- [ ] Create webhook to point to `fleet-ci`