### PR TITLE
Add ability to call diagnostics with V2 protocol and add defaults.

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -10,13 +10,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
 	"runtime/pprof"
 	"sync"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent-client/v7/pkg/utils"

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -5,10 +5,14 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
+	"runtime/pprof"
 	"sync"
 	"time"
 
@@ -89,6 +93,10 @@ type V2 interface {
 	//
 	// nil can be returned when the client has never connected.
 	AgentInfo() *AgentInfo
+	// RegisterDiagnosticHook registers a diagnostic hook function that will get called when diagnostics is called for
+	// as specific unit. Registering the hook at the client level means it will be called for every unit that has
+	// diagnostics requested.
+	RegisterDiagnosticHook(name string, description string, filename string, contentType string, hook DiagnosticHook)
 }
 
 // clientV2 manages the state and communication to the Elastic Agent over the V2 control protocol.
@@ -116,6 +124,9 @@ type clientV2 struct {
 	unitsMu sync.RWMutex
 	units   []*Unit
 
+	dmx       sync.RWMutex
+	diagHooks map[string]diagHook
+
 	storeClient    proto.ElasticAgentStoreClient
 	artifactClient proto.ElasticAgentArtifactClient
 	logClient      proto.ElasticAgentLogClient
@@ -126,7 +137,7 @@ type clientV2 struct {
 
 // NewV2 creates a client connection to Elastic Agent over the V2 control protocol.
 func NewV2(target string, token string, versionInfo VersionInfo, opts ...grpc.DialOption) V2 {
-	return &clientV2{
+	c := &clientV2{
 		target:          target,
 		opts:            opts,
 		token:           token,
@@ -134,8 +145,11 @@ func NewV2(target string, token string, versionInfo VersionInfo, opts ...grpc.Di
 		kickCh:          make(chan struct{}, 1),
 		errCh:           make(chan error),
 		unitsCh:         make(chan UnitChanged),
+		diagHooks:       make(map[string]diagHook),
 		minCheckTimeout: CheckinMinimumTimeout,
 	}
+	c.registerDefaultDiagnostics()
+	return c
 }
 
 // Start starts the connection to Elastic Agent.
@@ -186,6 +200,20 @@ func (c *clientV2) AgentInfo() *AgentInfo {
 	c.agentInfoMu.RLock()
 	defer c.agentInfoMu.RUnlock()
 	return c.agentInfo
+}
+
+// RegisterDiagnosticHook registers a diagnostic hook function that will get called when diagnostics is called for
+// as specific unit. Registering the hook at the client level means it will be called for every unit that has
+// diagnostics requested.
+func (c *clientV2) RegisterDiagnosticHook(name string, description string, filename string, contentType string, hook DiagnosticHook) {
+	c.dmx.Lock()
+	defer c.dmx.Unlock()
+	c.diagHooks[name] = diagHook{
+		description: description,
+		filename:    filename,
+		contentType: contentType,
+		hook:        hook,
+	}
 }
 
 // startCheckin starts the go routines to send and receive check-ins
@@ -443,14 +471,7 @@ func (c *clientV2) actionRoundTrip(actionResults chan *proto.ActionResponse) {
 			case proto.ActionRequest_CUSTOM:
 				c.tryPerformAction(actionResults, action)
 			case proto.ActionRequest_DIAGNOSTICS:
-				// TODO: Implement the diagnostics action.
-				// At the moment it just returns action type unknown until implemented.
-				actionResults <- &proto.ActionResponse{
-					Token:  c.token,
-					Id:     action.Id,
-					Status: proto.ActionResponse_FAILED,
-					Result: ActionTypeUnknown,
-				}
+				c.tryPerformDiagnostics(actionResults, action)
 			default:
 				actionResults <- &proto.ActionResponse{
 					Token:  c.token,
@@ -579,6 +600,80 @@ func (c *clientV2) tryPerformAction(actionResults chan *proto.ActionResponse, ac
 			Result: resBytes,
 		}
 	}()
+}
+
+func (c *clientV2) tryPerformDiagnostics(actionResults chan *proto.ActionResponse, action *proto.ActionRequest) {
+	// find the unit
+	c.unitsMu.RLock()
+	unit := c.findUnit(action.UnitId, UnitType(action.UnitType))
+	c.unitsMu.RUnlock()
+	if unit == nil {
+		actionResults <- &proto.ActionResponse{
+			Token:  c.token,
+			Id:     action.Id,
+			Status: proto.ActionResponse_FAILED,
+			Result: ActionErrUnitNotFound,
+		}
+		return
+	}
+
+	// gather diagnostics hooks for this unit
+	diagHooks := make(map[string]diagHook)
+	c.dmx.RLock()
+	for n, d := range c.diagHooks {
+		diagHooks[n] = d
+	}
+	c.dmx.RUnlock()
+
+	// unit hooks after client hooks; allows unit specific to override client hooks
+	unit.dmx.RLock()
+	for n, d := range unit.diagHooks {
+		diagHooks[n] = d
+	}
+	unit.dmx.RUnlock()
+
+	// perform diagnostics in goroutine, so we don't block other work
+	go func() {
+		res := make([]*proto.ActionDiagnosticUnitResult, 0, len(diagHooks))
+		for n, d := range diagHooks {
+			content := d.hook()
+			res = append(res, &proto.ActionDiagnosticUnitResult{
+				Name:        n,
+				Filename:    d.filename,
+				Description: d.description,
+				ContentType: d.contentType,
+				Content:     content,
+				Generated:   timestamppb.New(time.Now().UTC()),
+			})
+		}
+		actionResults <- &proto.ActionResponse{
+			Token:      c.token,
+			Id:         action.Id,
+			Status:     proto.ActionResponse_SUCCESS,
+			Diagnostic: res,
+		}
+	}()
+}
+
+func (c *clientV2) registerDefaultDiagnostics() {
+	c.registerPprofDiagnostics("goroutine", "stack traces of all current goroutines")
+	c.registerPprofDiagnostics("heap", "a sampling of memory allocations of live objects")
+	c.registerPprofDiagnostics("allocs", "a sampling of all past memory allocations")
+	c.registerPprofDiagnostics("threadcreate", "stack traces that led to the creation of new OS threads")
+	c.registerPprofDiagnostics("block", "stack traces that led to blocking on synchronization primitives")
+	c.registerPprofDiagnostics("mutex", "stack traces of holders of contended mutexes")
+}
+
+func (c *clientV2) registerPprofDiagnostics(name string, description string) {
+	c.RegisterDiagnosticHook(name, description, fmt.Sprintf("%s.txt", name), "plain/text", func() []byte {
+		var w bytes.Buffer
+		err := pprof.Lookup(name).WriteTo(&w, 1)
+		if err != nil {
+			// error is returned as the content
+			return []byte(fmt.Sprintf("failed to write pprof to bytes buffer: %s", err))
+		}
+		return w.Bytes()
+	})
 }
 
 func inExpected(unit *Unit, expected []*proto.UnitExpected) bool {

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -94,7 +94,7 @@ type V2 interface {
 	// nil can be returned when the client has never connected.
 	AgentInfo() *AgentInfo
 	// RegisterDiagnosticHook registers a diagnostic hook function that will get called when diagnostics is called for
-	// as specific unit. Registering the hook at the client level means it will be called for every unit that has
+	// a specific unit. Registering the hook at the client level means it will be called for every unit that has
 	// diagnostics requested.
 	RegisterDiagnosticHook(name string, description string, filename string, contentType string, hook DiagnosticHook)
 }

--- a/pkg/client/client_v2_test.go
+++ b/pkg/client/client_v2_test.go
@@ -565,6 +565,13 @@ func TestClientV2_DiagnosticAction(t *testing.T) {
 	unit := units[0]
 	unitsMu.Unlock()
 
+	client.RegisterDiagnosticHook("custom_component", "customer diagnostic for the component", "custom_component.txt", "plain/text", func() []byte {
+		return []byte("custom component")
+	})
+	unit.RegisterDiagnosticHook("custom_unit", "custom diagnostic for the unit", "custom_unit.txt", "plain/text", func() []byte {
+		return []byte("custom unit")
+	})
+
 	res, err := srv.PerformDiagnostic(unit.id, proto.UnitType(unit.unitType))
 	assert.NoError(t, err)
 
@@ -572,7 +579,7 @@ func TestClientV2_DiagnosticAction(t *testing.T) {
 	for _, d := range res {
 		names = append(names, d.Name)
 	}
-	assert.ElementsMatch(t, names, []string{"goroutine", "heap", "allocs", "threadcreate", "block", "mutex"})
+	assert.ElementsMatch(t, names, []string{"goroutine", "heap", "allocs", "threadcreate", "block", "mutex", "custom_component", "custom_unit"})
 }
 
 func storeErrors(ctx context.Context, client V2, errs *[]error, lock *sync.Mutex) {

--- a/pkg/client/client_v2_test.go
+++ b/pkg/client/client_v2_test.go
@@ -472,6 +472,109 @@ func TestClientV2_Actions(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestClientV2_DiagnosticAction(t *testing.T) {
+	var m sync.Mutex
+	token := mock.NewID()
+	gotInit := false
+	srv := mock.StubServerV2{
+		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
+			if observed.Token == token {
+				return &proto.CheckinExpected{
+					Units: []*proto.UnitExpected{
+						{
+							Id:             mock.NewID(),
+							Type:           proto.UnitType_OUTPUT,
+							State:          proto.State_HEALTHY,
+							LogLevel:       proto.UnitLogLevel_INFO,
+							ConfigStateIdx: 1,
+							Config:         &proto.UnitExpectedConfig{},
+						},
+					},
+				}
+			}
+			// disconnect
+			return nil
+		},
+		ActionImpl: func(response *proto.ActionResponse) error {
+			m.Lock()
+			defer m.Unlock()
+
+			if response.Token != token {
+				return fmt.Errorf("invalid token")
+			}
+			if response.Id == "init" {
+				gotInit = true
+			}
+			return nil
+		},
+		ActionsChan: make(chan *mock.PerformAction, 100),
+		SentActions: make(map[string]*mock.PerformAction),
+	}
+	require.NoError(t, srv.Start())
+	defer srv.Stop()
+
+	var errsMu sync.Mutex
+	var errs []error
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := NewV2(fmt.Sprintf(":%d", srv.Port), token, VersionInfo{}, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	storeErrors(ctx, client, &errs, &errsMu)
+
+	var unitsMu sync.Mutex
+	var units []*Unit
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case change := <-client.UnitChanges():
+				switch change.Type {
+				case UnitChangedAdded:
+					unitsMu.Lock()
+					units = append(units, change.Unit)
+					unitsMu.Unlock()
+				default:
+					panic("not implemented")
+				}
+			}
+		}
+	}()
+
+	require.NoError(t, client.Start(ctx))
+	defer client.Stop()
+	require.NoError(t, waitFor(func() error {
+		m.Lock()
+		defer m.Unlock()
+
+		if !gotInit {
+			return fmt.Errorf("server never received valid token")
+		}
+		return nil
+	}))
+	require.NoError(t, waitFor(func() error {
+		unitsMu.Lock()
+		defer unitsMu.Unlock()
+
+		if len(units) != 1 {
+			return fmt.Errorf("client never got unit")
+		}
+		return nil
+	}))
+
+	unitsMu.Lock()
+	unit := units[0]
+	unitsMu.Unlock()
+
+	res, err := srv.PerformDiagnostic(unit.id, proto.UnitType(unit.unitType))
+	assert.NoError(t, err)
+
+	names := make([]string, 0, len(res))
+	for _, d := range res {
+		names = append(names, d.Name)
+	}
+	assert.ElementsMatch(t, names, []string{"goroutine", "heap", "allocs", "threadcreate", "block", "mutex"})
+}
+
 func storeErrors(ctx context.Context, client V2, errs *[]error, lock *sync.Mutex) {
 	go func() {
 		for {

--- a/pkg/client/diagnostics.go
+++ b/pkg/client/diagnostics.go
@@ -1,0 +1,15 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package client
+
+// DiagnosticHook is a function that returns content for a registered diagnostic hook.
+type DiagnosticHook func() []byte
+
+type diagHook struct {
+	description string
+	filename    string
+	contentType string
+	hook        DiagnosticHook
+}

--- a/pkg/client/mock/stub_serverV1.go
+++ b/pkg/client/mock/stub_serverV1.go
@@ -23,15 +23,18 @@ type StubServerAction func(*proto.ActionResponse) error
 
 // PerformAction is the stubbed action type for the mocked server
 type PerformAction struct {
-	Name     string
-	Params   []byte
-	Callback func(map[string]interface{}, error)
-	UnitID   string
-	UnitType proto.UnitType
+	Type         proto.ActionRequest_Type
+	Name         string
+	Params       []byte
+	Callback     func(map[string]interface{}, error)
+	DiagCallback func([]*proto.ActionDiagnosticUnitResult, error)
+	UnitID       string
+	UnitType     proto.UnitType
 }
 
 type actionResultCh struct {
 	Result map[string]interface{}
+	Diag   []*proto.ActionDiagnosticUnitResult
 	Err    error
 }
 


### PR DESCRIPTION
## Overview

Completes the TODO for supporting the new diagnostics for the V2 protocol. With this change any component that uses the client gets all the defaults from the runtime/pprof included.

The client can have diagnostics that each unit will inherit and then each unit can define its own diagnostic as well.

Elastic Agent will call this per unit to provide all the diagnostics information for the running components unit.