### PR TITLE
Change struct compare statement in unit update

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent-client/v7/pkg/utils"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // UnitChangedType defines types for when units are adjusted.
@@ -386,7 +385,6 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 		} else {
 			// existing unit
 			if unit.updateState(UnitState(agentUnit.State), UnitLogLevel(agentUnit.LogLevel), agentUnit.Config, agentUnit.ConfigStateIdx) {
-				logp.L().Debugf("Will send unit update for %s", unit.id)
 				c.unitsCh <- UnitChanged{
 					Type: UnitChangedModified,
 					Unit: unit,

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/elastic-agent-client/v7/pkg/utils"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // UnitChangedType defines types for when units are adjusted.
@@ -385,6 +386,7 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 		} else {
 			// existing unit
 			if unit.updateState(UnitState(agentUnit.State), UnitLogLevel(agentUnit.LogLevel), agentUnit.Config, agentUnit.ConfigStateIdx) {
+				logp.L().Debugf("Will send unit update for %s", unit.id)
 				c.unitsCh <- UnitChanged{
 					Type: UnitChangedModified,
 					Unit: unit,

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -8,10 +8,10 @@ import (
 	"reflect"
 	"sync"
 
+	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // UnitType is the type of the unit, either input or output
@@ -252,7 +252,6 @@ func (u *Unit) RegisterDiagnosticHook(name string, description string, filename 
 
 // updateConfig updates the configuration for this unit, triggering the delegate function if set.
 func (u *Unit) updateState(exp UnitState, logLevel UnitLogLevel, cfg *proto.UnitExpectedConfig, cfgIdx uint64) bool {
-	log := logp.L()
 	u.expMu.Lock()
 	defer u.expMu.Unlock()
 	changed := false
@@ -266,7 +265,7 @@ func (u *Unit) updateState(exp UnitState, logLevel UnitLogLevel, cfg *proto.Unit
 	}
 	if u.configIdx != cfgIdx {
 		u.configIdx = cfgIdx
-		if !reflect.DeepEqual(u.config.Source.AsMap(), cfg.Source.AsMap()) {
+		if !gproto.Equal(u.config.Source.ProtoReflect().Interface(), cfg.Source.ProtoReflect().Interface()) {
 			u.config = cfg
 			changed = true
 		}

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -265,7 +265,7 @@ func (u *Unit) updateState(exp UnitState, logLevel UnitLogLevel, cfg *proto.Unit
 	}
 	if u.configIdx != cfgIdx {
 		u.configIdx = cfgIdx
-		if !gproto.Equal(u.config.Source.ProtoReflect().Interface(), cfg.Source.ProtoReflect().Interface()) {
+		if !gproto.Equal(u.config.Source, cfg.Source) {
 			u.config = cfg
 			changed = true
 		}

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // UnitType is the type of the unit, either input or output
@@ -251,6 +252,7 @@ func (u *Unit) RegisterDiagnosticHook(name string, description string, filename 
 
 // updateConfig updates the configuration for this unit, triggering the delegate function if set.
 func (u *Unit) updateState(exp UnitState, logLevel UnitLogLevel, cfg *proto.UnitExpectedConfig, cfgIdx uint64) bool {
+	log := logp.L()
 	u.expMu.Lock()
 	defer u.expMu.Unlock()
 	changed := false
@@ -264,7 +266,7 @@ func (u *Unit) updateState(exp UnitState, logLevel UnitLogLevel, cfg *proto.Unit
 	}
 	if u.configIdx != cfgIdx {
 		u.configIdx = cfgIdx
-		if u.config != cfg {
+		if !reflect.DeepEqual(u.config.Source.AsMap(), cfg.Source.AsMap()) {
 			u.config = cfg
 			changed = true
 		}

--- a/pkg/client/unit_test.go
+++ b/pkg/client/unit_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestUnitUpdateWithSameMap(t *testing.T) {
+	sameStruct := map[string]interface{}{"username": "test"}
+	pbStruct, err := structpb.NewStruct(sameStruct)
+	require.NoError(t, err)
+	existingUnit := Unit{
+		exp:       UnitStateHealthy,
+		logLevel:  UnitLogLevelDebug,
+		configIdx: 1,
+		config:    &proto.UnitExpectedConfig{Source: pbStruct},
+	}
+
+	pbStructNew, err := structpb.NewStruct(sameStruct)
+	newUnit := &proto.UnitExpectedConfig{
+		Source: pbStructNew,
+	}
+	// This should return false, as the two underlying maps in `source` are the same
+	result := existingUnit.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
+	require.False(t, result)
+}
+
+func TestUnitUpdateWithNewMap(t *testing.T) {
+	pbStruct, err := structpb.NewStruct(map[string]interface{}{"username": "test"})
+	require.NoError(t, err)
+	existingUnit := Unit{
+		exp:       UnitStateHealthy,
+		logLevel:  UnitLogLevelDebug,
+		configIdx: 1,
+		config:    &proto.UnitExpectedConfig{Source: pbStruct},
+	}
+
+	pbStructNew, err := structpb.NewStruct(map[string]interface{}{"username": "other"})
+	newUnit := &proto.UnitExpectedConfig{
+		Source: pbStructNew,
+	}
+
+	// This should return true, as we have an actually new map
+	result := existingUnit.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
+	require.True(t, result)
+}
+
+func TestUnitUpdateLog(t *testing.T) {
+	existingUnit := Unit{
+		exp:       UnitStateHealthy,
+		logLevel:  UnitLogLevelDebug,
+		configIdx: 1,
+		config:    &proto.UnitExpectedConfig{},
+	}
+
+	// This should return true, as we have an actually new map
+	result := existingUnit.updateState(UnitStateHealthy, UnitLogLevelInfo, &proto.UnitExpectedConfig{}, 2)
+	require.True(t, result)
+}
+
+func TestUnitUpdateState(t *testing.T) {
+	existingUnit := Unit{
+		exp:       UnitStateHealthy,
+		logLevel:  UnitLogLevelDebug,
+		configIdx: 1,
+		config:    &proto.UnitExpectedConfig{},
+	}
+
+	// This should return true, as we have an actually new map
+	result := existingUnit.updateState(UnitStateStopped, UnitLogLevelInfo, &proto.UnitExpectedConfig{}, 2)
+	require.True(t, result)
+}

--- a/pkg/client/unit_test.go
+++ b/pkg/client/unit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/stretchr/testify/require"
+	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -29,6 +30,10 @@ func TestUnitUpdateWithSameMap(t *testing.T) {
 	newUnit := &proto.UnitExpectedConfig{
 		Source: pbStructNew,
 	}
+	// Marshal the message to populate the size cache and ensure the internal proto files are populated.
+	_, err = gproto.Marshal(newUnit)
+	require.NoError(t, err)
+
 	// This should return false, as the two underlying maps in `source` are the same
 	result := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
 	require.False(t, result)
@@ -45,6 +50,10 @@ func TestUnitUpdateWithNewMap(t *testing.T) {
 	newUnit := &proto.UnitExpectedConfig{
 		Source: pbStructNew,
 	}
+
+	_, err = gproto.Marshal(newUnit)
+	require.NoError(t, err)
+
 	// This should return true, as we have an actually new map
 	result := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
 	require.True(t, result)

--- a/pkg/client/unit_test.go
+++ b/pkg/client/unit_test.go
@@ -8,68 +8,51 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestUnitUpdateWithSameMap(t *testing.T) {
-	sameStruct := map[string]interface{}{"username": "test"}
-	pbStruct, err := structpb.NewStruct(sameStruct)
-	require.NoError(t, err)
-	existingUnit := Unit{
-		exp:       UnitStateHealthy,
-		logLevel:  UnitLogLevelDebug,
-		configIdx: 1,
-		config:    &proto.UnitExpectedConfig{Source: pbStruct},
-	}
+var defaultTest = Unit{
+	exp:       UnitStateHealthy,
+	logLevel:  UnitLogLevelDebug,
+	configIdx: 1,
+	config:    &proto.UnitExpectedConfig{},
+}
 
-	pbStructNew, err := structpb.NewStruct(sameStruct)
+func TestUnitUpdateWithSameMap(t *testing.T) {
+	defaultTest.configIdx = 1
+	sameMap := map[string]interface{}{"username": "test"}
+	pbStruct, err := structpb.NewStruct(sameMap)
+	require.NoError(t, err)
+	defaultTest.config.Source = pbStruct
+
+	pbStructNew, err := structpb.NewStruct(sameMap)
 	newUnit := &proto.UnitExpectedConfig{
 		Source: pbStructNew,
 	}
 	// This should return false, as the two underlying maps in `source` are the same
-	result := existingUnit.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
+	result := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
 	require.False(t, result)
 }
 
 func TestUnitUpdateWithNewMap(t *testing.T) {
+	defaultTest.configIdx = 1
 	pbStruct, err := structpb.NewStruct(map[string]interface{}{"username": "test"})
 	require.NoError(t, err)
-	existingUnit := Unit{
-		exp:       UnitStateHealthy,
-		logLevel:  UnitLogLevelDebug,
-		configIdx: 1,
-		config:    &proto.UnitExpectedConfig{Source: pbStruct},
-	}
+	defaultTest.config.Source = pbStruct
 
 	pbStructNew, err := structpb.NewStruct(map[string]interface{}{"username": "other"})
+	require.NoError(t, err)
 	newUnit := &proto.UnitExpectedConfig{
 		Source: pbStructNew,
 	}
-
 	// This should return true, as we have an actually new map
-	result := existingUnit.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
+	result := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, newUnit, 2)
 	require.True(t, result)
 }
 
 func TestUnitUpdateLog(t *testing.T) {
-	existingUnit := Unit{
-		exp:       UnitStateHealthy,
-		logLevel:  UnitLogLevelDebug,
-		configIdx: 1,
-		config:    &proto.UnitExpectedConfig{},
-	}
-
-	// This should return true, as we have an actually new map
-	result := existingUnit.updateState(UnitStateHealthy, UnitLogLevelInfo, &proto.UnitExpectedConfig{}, 2)
+	result := defaultTest.updateState(UnitStateHealthy, UnitLogLevelInfo, &proto.UnitExpectedConfig{}, 2)
 	require.True(t, result)
 }
 
 func TestUnitUpdateState(t *testing.T) {
-	existingUnit := Unit{
-		exp:       UnitStateHealthy,
-		logLevel:  UnitLogLevelDebug,
-		configIdx: 1,
-		config:    &proto.UnitExpectedConfig{},
-	}
-
-	// This should return true, as we have an actually new map
-	result := existingUnit.updateState(UnitStateStopped, UnitLogLevelInfo, &proto.UnitExpectedConfig{}, 2)
+	result := defaultTest.updateState(UnitStateStopped, UnitLogLevelInfo, &proto.UnitExpectedConfig{}, 2)
 	require.True(t, result)
 }

--- a/pkg/client/unit_test.go
+++ b/pkg/client/unit_test.go
@@ -1,3 +1,6 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
 package client
 
 import (


### PR DESCRIPTION
First PR to fix https://github.com/elastic/elastic-agent/issues/1738 and https://github.com/elastic/apm-server/pull/9544#issuecomment-1316473137

This attempts to fix an underlying issue where V2 clients are seeing unit update events where the config has apparently remained unchanged. In order for that change event to be generated, The underlying unit needs to have an incremented config index, and a different config. I'm not sure why we're seeing an incremented index, but this at least fixes how we try to compare the structs. Instead of `!=` on two pointers, this does a `reflect.DeepEqual` on the underlying source config.