### PR TITLE
Always send observed after removals

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -359,6 +359,7 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 	c.unitsMu.Lock()
 	defer c.unitsMu.Unlock()
 	i := 0
+	removed := false
 	for _, unit := range c.units {
 		if inExpected(unit, expected.Units) {
 			c.units[i] = unit
@@ -368,6 +369,7 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 				Type: UnitChangedRemoved,
 				Unit: unit,
 			}
+			removed = true
 		}
 	}
 	// resize so units that no longer exist are removed from the slice
@@ -391,6 +393,11 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 				}
 			}
 		}
+	}
+	if removed {
+		// unit removed send updated observed change so agent is notified now
+		// otherwise it will not be notified until the next checkin timeout
+		c.unitChanged()
 	}
 }
 


### PR DESCRIPTION
# Overview

This changes the logic to always to send the observed state once a unit has been removed.

# Why is this needed?

With out this change when units are removed the observed state is not sent to the Elastic Agent until the next checkin timeout which can be up to 25 seconds.