### PR TITLE
Use GetSource() calls to compare structs in updateState()

### DIFF
--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -265,7 +265,7 @@ func (u *Unit) updateState(exp UnitState, logLevel UnitLogLevel, cfg *proto.Unit
 	}
 	if u.configIdx != cfgIdx {
 		u.configIdx = cfgIdx
-		if !gproto.Equal(u.config.Source, cfg.Source) {
+		if !gproto.Equal(u.config.GetSource(), cfg.GetSource()) {
 			u.config = cfg
 			changed = true
 		}


### PR DESCRIPTION
Fixes a panic I noticed while writing tests, we can get a nil reference if we forget to include a source field. This just uses the proper `Get*()` calls so we can avoid that.