### PR TITLE
Send feature flags information as part of observed state in the next checkin

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -194,7 +194,6 @@ type clientV2 struct {
 	units              []*Unit
 
 	featuresMu  sync.RWMutex
-	features    *proto.Features
 	featuresIdx uint64
 
 	dmx       sync.RWMutex
@@ -409,7 +408,6 @@ func (c *clientV2) sendObserved(client proto.ElasticAgent_CheckinV2Client) error
 	msg := &proto.CheckinObserved{
 		Token:       c.token,
 		Units:       observed,
-		Features:    c.features,
 		FeaturesIdx: c.featuresIdx,
 		VersionInfo: nil,
 	}
@@ -507,10 +505,10 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 	}
 
 	// Now that we've propagated feature flags' information to units, record
-	// the same information on the client so we can send it up as part of the observed state in the next checkin.
+	// the featuresIdx on the client so we can send it up as part of the observed
+	// state in the next checkin.
 	c.featuresMu.Lock()
 	defer c.featuresMu.Unlock()
-	c.features = expected.Features
 	c.featuresIdx = expected.FeaturesIdx
 
 	if removed {

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -507,9 +507,7 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 	}
 
 	// Now that we've propagated feature flags' information to units, record
-	// the same information on the client so we can send it up as part of the
-	// observed on c so we can send up as part of the observed state in the next
-	// checkin.
+	// the same information on the client so we can send it up as part of the observed state in the next checkin.
 	c.featuresMu.Lock()
 	defer c.featuresMu.Unlock()
 	c.features = expected.Features

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -193,6 +193,7 @@ type clientV2 struct {
 	unitsMu            sync.RWMutex
 	units              []*Unit
 
+	featuresMu  sync.RWMutex
 	features    *proto.Features
 	featuresIdx uint64
 
@@ -401,6 +402,10 @@ func (c *clientV2) sendObserved(client proto.ElasticAgent_CheckinV2Client) error
 		observed = append(observed, unit.toObserved())
 	}
 	c.unitsMu.RUnlock()
+
+	c.featuresMu.RLock()
+	defer c.featuresMu.RUnlock()
+
 	msg := &proto.CheckinObserved{
 		Token:       c.token,
 		Units:       observed,
@@ -505,6 +510,8 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 	// the same information on the client so we can send it up as part of the
 	// observed on c so we can send up as part of the observed state in the next
 	// checkin.
+	c.featuresMu.Lock()
+	defer c.featuresMu.Unlock()
 	c.features = expected.Features
 	c.featuresIdx = expected.FeaturesIdx
 

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -193,6 +193,9 @@ type clientV2 struct {
 	unitsMu            sync.RWMutex
 	units              []*Unit
 
+	features    *proto.Features
+	featuresIdx uint64
+
 	dmx       sync.RWMutex
 	diagHooks map[string]diagHook
 
@@ -401,6 +404,8 @@ func (c *clientV2) sendObserved(client proto.ElasticAgent_CheckinV2Client) error
 	msg := &proto.CheckinObserved{
 		Token:       c.token,
 		Units:       observed,
+		Features:    c.features,
+		FeaturesIdx: c.featuresIdx,
 		VersionInfo: nil,
 	}
 	if !c.versionInfoSent {
@@ -496,11 +501,19 @@ func (c *clientV2) syncUnits(expected *proto.CheckinExpected) {
 		}
 	}
 
+	// Now that we've propagated feature flags' information to units, record
+	// the same information on the client so we can send it up as part of the
+	// observed on c so we can send up as part of the observed state in the next
+	// checkin.
+	c.features = expected.Features
+	c.featuresIdx = expected.FeaturesIdx
+
 	if removed {
 		// unit removed send updated observed change so agent is notified now
 		// otherwise it will not be notified until the next checkin timeout
 		c.unitChanged()
 	}
+
 }
 
 // findUnit finds an existing unit.


### PR DESCRIPTION
Follow up to https://github.com/elastic/elastic-agent-client/pull/56.

While updating the `management.TestManagerV2` test in https://github.com/elastic/beats/pull/34456 to account for feature flags, I realized `elastic-agent-client` wasn't reporting it's current feature flag status in the observed state sent to the server (Agent) during checkin.  This PR fixes that miss.