### PR TITLE
Fix RPC error spinlock / clean up clientV2

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"runtime/pprof"
 	"strings"
 	"sync"
@@ -315,9 +314,7 @@ func (c *clientV2) checkinRoundTrip() {
 	defer checkinCancel()
 
 	// Return immediately if we can't establish an initial RPC connection.
-	checkinClient, err := c.client.CheckinV2(checkinCtx,
-		grpc_retry.WithMax(math.MaxUint),
-		grpc_retry.WithPerRetryTimeout(1*time.Second))
+	checkinClient, err := c.client.CheckinV2(checkinCtx, grpc_retry.WithPerRetryTimeout(1*time.Second))
 	if err != nil {
 		c.errCh <- err
 		return
@@ -568,9 +565,7 @@ func (c *clientV2) actionRoundTrip(actionResults chan *proto.ActionResponse) {
 	defer actionsCancel()
 
 	// Return immediately if we can't establish an initial RPC connection.
-	actionsClient, err := c.client.Actions(actionsCtx,
-		grpc_retry.WithMax(math.MaxUint),
-		grpc_retry.WithPerRetryTimeout(1*time.Second))
+	actionsClient, err := c.client.Actions(actionsCtx, grpc_retry.WithPerRetryTimeout(1*time.Second))
 	if err != nil {
 		c.errCh <- err
 		return

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"runtime/pprof"
 	"strings"
 	"sync"
@@ -314,7 +315,9 @@ func (c *clientV2) checkinRoundTrip() {
 	defer checkinCancel()
 
 	// Return immediately if we can't establish an initial RPC connection.
-	checkinClient, err := c.client.CheckinV2(checkinCtx, grpc_retry.WithPerRetryTimeout(1*time.Second))
+	checkinClient, err := c.client.CheckinV2(checkinCtx,
+		grpc_retry.WithMax(math.MaxUint),
+		grpc_retry.WithPerRetryTimeout(1*time.Second))
 	if err != nil {
 		c.errCh <- err
 		return
@@ -565,7 +568,9 @@ func (c *clientV2) actionRoundTrip(actionResults chan *proto.ActionResponse) {
 	defer actionsCancel()
 
 	// Return immediately if we can't establish an initial RPC connection.
-	actionsClient, err := c.client.Actions(actionsCtx, grpc_retry.WithPerRetryTimeout(1*time.Second))
+	actionsClient, err := c.client.Actions(actionsCtx,
+		grpc_retry.WithMax(math.MaxUint),
+		grpc_retry.WithPerRetryTimeout(1*time.Second))
 	if err != nil {
 		c.errCh <- err
 		return

--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -303,8 +302,23 @@ func (c *clientV2) startCheckin() {
 
 	go func() {
 		defer c.wg.Done()
+		// If the initial RPC connection fails, checkinRoundTrip
+		// returns immediately, so we set a timer to avoid spinlocking
+		// on the error.
+		retryTimer := time.NewTimer(1 * time.Second)
 		for c.ctx.Err() == nil {
 			c.checkinRoundTrip()
+
+			// After the RPC client closes, wait until either the timer interval
+			// expires or the context is cancelled. Note that the timer waits
+			// one second since the checkinRoundTrip was last _called_, not
+			// since it returns; immediate retries are ok after an active
+			// connection shuts down.
+			select {
+			case <-retryTimer.C:
+				retryTimer.Reset(1 * time.Second)
+			case <-c.ctx.Done():
+			}
 		}
 	}()
 }
@@ -314,7 +328,7 @@ func (c *clientV2) checkinRoundTrip() {
 	defer checkinCancel()
 
 	// Return immediately if we can't establish an initial RPC connection.
-	checkinClient, err := c.client.CheckinV2(checkinCtx, grpc_retry.WithPerRetryTimeout(1*time.Second))
+	checkinClient, err := c.client.CheckinV2(checkinCtx)
 	if err != nil {
 		c.errCh <- err
 		return
@@ -554,8 +568,23 @@ func (c *clientV2) startActions() {
 	actionResults := make(chan *proto.ActionResponse, 100)
 	go func() {
 		defer c.wg.Done()
+		// If the initial RPC connection fails, actionRoundTrip
+		// returns immediately, so we set a timer to avoid spinlocking
+		// on the error.
+		retryTimer := time.NewTimer(1 * time.Second)
 		for c.ctx.Err() == nil {
 			c.actionRoundTrip(actionResults)
+
+			// After the RPC client closes, wait until either the timer interval
+			// expires or the context is cancelled. Note that the timer waits
+			// one second since the checkinRoundTrip was last _called_, not
+			// since it returns; immediate retries are ok after an active
+			// connection shuts down.
+			select {
+			case <-retryTimer.C:
+				retryTimer.Reset(1 * time.Second)
+			case <-c.ctx.Done():
+			}
 		}
 	}()
 }
@@ -565,7 +594,7 @@ func (c *clientV2) actionRoundTrip(actionResults chan *proto.ActionResponse) {
 	defer actionsCancel()
 
 	// Return immediately if we can't establish an initial RPC connection.
-	actionsClient, err := c.client.Actions(actionsCtx, grpc_retry.WithPerRetryTimeout(1*time.Second))
+	actionsClient, err := c.client.Actions(actionsCtx)
 	if err != nil {
 		c.errCh <- err
 		return

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -207,7 +207,7 @@ func (u *Unit) UpdateState(state UnitState, message string, payload map[string]i
 		changed = true
 	}
 	if changed {
-		u.client.unitChanged()
+		u.client.unitsStateChanged()
 	}
 	return nil
 }


### PR DESCRIPTION
Add a minimum timeout to `(*clientV2).startCheckin` and `(*clientV2).startActions` so retries of `checkinRoundTrip` and `actionRoundTrip` don't spinlock if there's an RPC error (see https://github.com/elastic/elastic-agent-client/issues/66).

Fixes https://github.com/elastic/elastic-agent-client/issues/66.
fix https://github.com/elastic/elastic-agent/issues/2628


At the same time, break some monolithic functions up into multiple helpers, fix some race conditions, simplify the synchronization variables, and add explanatory comments for many steps of the checkin process.