### PR TITLE
Allow dial options when initializing a V2 client from reader

### DIFF
--- a/pkg/client/reader.go
+++ b/pkg/client/reader.go
@@ -63,7 +63,7 @@ func NewFromReader(reader io.Reader, impl StateInterface, actions ...Action) (Cl
 }
 
 // NewV2FromReader creates a new V2 client reading the connection information from the io.Reader.
-func NewV2FromReader(reader io.Reader, ver VersionInfo) (V2, []Service, error) {
+func NewV2FromReader(reader io.Reader, ver VersionInfo, opts ...grpc.DialOption) (V2, []Service, error) {
 	connInfo := &proto.ConnInfo{}
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
@@ -87,7 +87,12 @@ func NewV2FromReader(reader io.Reader, ver VersionInfo) (V2, []Service, error) {
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 	})
-	client := NewV2(connInfo.Addr, connInfo.Token, ver, grpc.WithTransportCredentials(trans))
+	client := NewV2(
+		connInfo.Addr,
+		connInfo.Token,
+		ver,
+		append(opts, grpc.WithTransportCredentials(trans))...,
+	)
 	services := make([]Service, 0, len(connInfo.Services))
 	for _, srv := range connInfo.Services {
 		services = append(services, Service(srv))


### PR DESCRIPTION
I want to enable gRPC interceptors with this client, so we can get telemetry/tracing with them.
However, while `NewV2` accepts a set of DialOptions, NewV2FromReader, which calls the same method under the hood doesn't.