### PR TITLE
Allow to set a port for the V2 stub server

### DIFF
--- a/pkg/client/mock/stub_serverV2.go
+++ b/pkg/client/mock/stub_serverV2.go
@@ -57,7 +57,7 @@ type StubServerV2 struct {
 
 // Start the mock server
 func (s *StubServerV2) Start(opt ...grpc.ServerOption) error {
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.Port))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow to set a port to `StubServerV2`. If its `Port` field is set, this is the port used to open the TCP listener, if no port is set a random one will be used. In all cases after `Start` is called, the `Port` field will contain the port the server is listening on.

Closes https://github.com/elastic/elastic-agent-client/issues/42