### PR TITLE
Upgrade to go 1.21.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-agent-client/v7
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gofrs/uuid v4.2.0+incompatible


### PR DESCRIPTION
What the title says. Only change is the minor version in the go.mod file.