### PR TITLE
stub server v2: set target from listener

### DIFF
--- a/pkg/client/mock/stub_serverV2.go
+++ b/pkg/client/mock/stub_serverV2.go
@@ -82,7 +82,7 @@ func (s *StubServerV2) listen(opt ...grpc.ServerOption) (lis net.Listener, clean
 			return nil, nil, err
 		}
 		s.Port = lis.Addr().(*net.TCPAddr).Port
-		s.target = fmt.Sprintf(":%d", s.Port)
+		s.target = lis.Addr().String()
 		return lis, cleanup, nil
 	}
 


### PR DESCRIPTION
Instead of the unspecified IP address use the `Addr()` from [`Listener`](https://pkg.go.dev/net#Listener) to set the value of target.