### PR TITLE
Allow bot triggered PRs to run CI

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
             "pipelineSlug": "elastic-agent-client",
             "allow_org_users": true,
             "allowed_repo_permissions": ["admin", "write"],
-            "allowed_list": [ ],
+            "allowed_list": ["dependabot[bot]", "mergify[bot]"],
             "set_commit_status": true,
             "build_on_commit": true,
             "build_on_comment": true,


### PR DESCRIPTION
This commit allows Buildkite run CI for bots generated by the dependabot and mergify bots, thus removing the need to manually allow execution with the trigger phrase.