### PR TITLE
Bump Golang for CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 env:
-  SETUP_GOLANG_VERSION: '1.18.10'
+  SETUP_GOLANG_VERSION: '1.21.8'
 
 steps:
   - label: "Update"


### PR DESCRIPTION
This commit bumps the Golang version (used by the container image for CI steps) to fix the failing lint test.

Closes #104