### PR TITLE
[Unit/Change]: trigger config change on unit config and revision changes

### DIFF
--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -325,40 +325,8 @@ func (u *Unit) updateState(
 
 	if u.configIdx != cfgIdx {
 		u.configIdx = cfgIdx
-		if !gproto.Equal(u.config.GetSource(), cfg.GetSource()) {
-			u.config = cfg
-			triggers |= TriggeredConfigChange
-		}
-	}
-
-	if u.config.GetRevision() != cfg.GetRevision() {
 		u.config = cfg
 		triggers |= TriggeredConfigChange
-	}
-
-	switch {
-	case u.config == cfg:
-		break
-	case u.config != nil && cfg == nil:
-		u.config = cfg
-		triggers |= TriggeredConfigChange
-	case u.config == nil && cfg != nil:
-		u.config = cfg
-		triggers |= TriggeredConfigChange
-	case u.config != nil && cfg != nil:
-		if len(u.config.Streams) != len(cfg.Streams) {
-			u.config = cfg
-			triggers |= TriggeredConfigChange
-			break
-		}
-
-		for idx, stream := range cfg.Streams {
-			if !gproto.Equal(stream, cfg.Streams[idx]) {
-				u.config = cfg
-				triggers |= TriggeredConfigChange
-				break
-			}
-		}
 	}
 
 	if !gproto.Equal(u.apm, expAPM) {

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -331,6 +331,29 @@ func (u *Unit) updateState(
 		}
 	}
 
+	switch {
+	case u.config != nil && cfg == nil:
+		u.config = cfg
+		triggers |= TriggeredConfigChange
+	case u.config == nil && cfg != nil:
+		u.config = cfg
+		triggers |= TriggeredConfigChange
+	case u.config != nil && cfg != nil:
+		if len(u.config.Streams) != len(cfg.Streams) {
+			u.config = cfg
+			triggers |= TriggeredConfigChange
+			break
+		}
+
+		for idx, stream := range cfg.Streams {
+			if !gproto.Equal(stream, cfg.Streams[idx]) {
+				u.config = cfg
+				triggers |= TriggeredConfigChange
+				break
+			}
+		}
+	}
+
 	if !gproto.Equal(u.apm, expAPM) {
 		u.apm = expAPM
 		triggers |= TriggeredAPMChange

--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -331,7 +331,14 @@ func (u *Unit) updateState(
 		}
 	}
 
+	if u.config.GetRevision() != cfg.GetRevision() {
+		u.config = cfg
+		triggers |= TriggeredConfigChange
+	}
+
 	switch {
+	case u.config == cfg:
+		break
 	case u.config != nil && cfg == nil:
 		u.config = cfg
 		triggers |= TriggeredConfigChange

--- a/pkg/client/unit_test.go
+++ b/pkg/client/unit_test.go
@@ -38,9 +38,13 @@ func TestUnitUpdateWithSameMap(t *testing.T) {
 	_, err = gproto.Marshal(newUnit)
 	require.NoError(t, err)
 
+	// This should return TriggeredNothing, as the configIdx hasn't changed
+	got := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, 0, nil, newUnit, 1, nil)
+	assert.Equal(t, TriggeredNothing, got)
+
 	// This should return TriggeredConfigChange, as the configIdx has changed (this is our criteria)
 	// no matter if the actual map is the same
-	got := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, 0, nil, newUnit, 2, nil)
+	got = defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, 0, nil, newUnit, 2, nil)
 	assert.Equal(t, TriggeredConfigChange, got)
 }
 

--- a/pkg/client/unit_test.go
+++ b/pkg/client/unit_test.go
@@ -38,9 +38,10 @@ func TestUnitUpdateWithSameMap(t *testing.T) {
 	_, err = gproto.Marshal(newUnit)
 	require.NoError(t, err)
 
-	// This should return TriggeredNothing, as the two underlying maps in `source` are the same
+	// This should return TriggeredConfigChange, as the configIdx has changed (this is our criteria)
+	// no matter if the actual map is the same
 	got := defaultTest.updateState(UnitStateHealthy, UnitLogLevelDebug, 0, nil, newUnit, 2, nil)
-	assert.Equal(t, TriggeredNothing, got)
+	assert.Equal(t, TriggeredConfigChange, got)
 }
 
 func TestUnitUpdateWithNewMap(t *testing.T) {


### PR DESCRIPTION
This PR adds checks for the RevisionNumber and Streams of the UnitExpectedConfig to properly cause a `TriggeredConfigChange`. 

@blakerouse I think you are the original implementor of the new control protocol, so any thoughts on that?