### PR TITLE
Replace go get usage

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -52,7 +52,7 @@ func (Prepare) InstallGoLicenser() error {
 
 // InstallGoLint for the code.
 func (Prepare) InstallGoLint() error {
-	GoInstall(fmt.Sprintf("%s@latest", goLintRepo))
+	return GoInstall(fmt.Sprintf("%s@latest", goLintRepo))
 }
 
 // All runs prepare:installGoLicenser and prepare:installGoLint.

--- a/magefile.go
+++ b/magefile.go
@@ -47,7 +47,7 @@ type Check mg.Namespace
 
 // InstallGoLicenser install go-licenser to check license of the files.
 func (Prepare) InstallGoLicenser() error {
-	return GoGet(goLicenserRepo)
+	return GoInstall(fmt.Sprintf("%s@latest", goLicenserRepo))
 }
 
 // InstallGoLint for the code.
@@ -162,7 +162,7 @@ func (Check) License() error {
 
 // GoGet fetch a remote dependencies.
 func GoGet(link string) error {
-	_, err := sh.Exec(map[string]string{"GO111MODULE": "off"}, os.Stdout, os.Stderr, "go", "get", link)
+	_, err := sh.Exec(map[string]string{}, os.Stdout, os.Stderr, "go", "get", link)
 	return err
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -52,7 +52,7 @@ func (Prepare) InstallGoLicenser() error {
 
 // InstallGoLint for the code.
 func (Prepare) InstallGoLint() error {
-	return GoGet(goLintRepo)
+	GoInstall(fmt.Sprintf("%s@latest", goLintRepo))
 }
 
 // All runs prepare:installGoLicenser and prepare:installGoLint.


### PR DESCRIPTION
As explained by @fearful-symmetry in https://github.com/elastic/elastic-agent-client/pull/110#issuecomment-2129967660:

> the `go get` operation we're using breaks on 1.22:
> ```
> mage prepare:all                                                                                                                                                
> go: modules disabled by GO111MODULE=off; see 'go help modules'
> Error: running "go get github.com/elastic/go-licenser" failed with exit code 1
> ```
> 
> I'm guessing the original code did this since it was a bit of a hack to install binaries without using `go install` However, this > doesn't work in go 1.22 anymore:
> https://tip.golang.org/doc/go1.22
> 
>> go get is no longer supported outside of a module in the legacy GOPATH mode (that is, with GO111MODULE=off). Other build commands, such as go build and go test, will continue to work indefinitely for legacy GOPATH programs.
