### PR TITLE
Add management mode to client-side AgentInfo structs

### DIFF
--- a/pkg/client/client_v2.go
+++ b/pkg/client/client_v2.go
@@ -143,6 +143,8 @@ type AgentInfo struct {
 	Version string
 	// Snapshot is true when the running version of the Elastic Agent is a snapshot.
 	Snapshot bool
+	// IsStandalone reports if the agent is running in standalone or managed mode
+	ManagedMode proto.AgentManagedMode
 }
 
 // VersionInfo is the version information for the connecting client.
@@ -573,9 +575,10 @@ func (c *clientV2) applyExpected(expected *proto.CheckinExpected) {
 	if expected.AgentInfo != nil {
 		c.agentInfoMu.Lock()
 		c.agentInfo = &AgentInfo{
-			ID:       expected.AgentInfo.Id,
-			Version:  expected.AgentInfo.Version,
-			Snapshot: expected.AgentInfo.Snapshot,
+			ID:          expected.AgentInfo.Id,
+			Version:     expected.AgentInfo.Version,
+			Snapshot:    expected.AgentInfo.Snapshot,
+			ManagedMode: expected.AgentInfo.Mode,
 		}
 		c.agentInfoMu.Unlock()
 	}

--- a/pkg/client/client_v2_test.go
+++ b/pkg/client/client_v2_test.go
@@ -158,9 +158,10 @@ func testClientV2CheckinInitial(t *testing.T, localRPC string, serverCreds, clie
 	packageVersion := "8.13.0+build20060102"
 	wantBuildHash := "build_hash"
 	wantAgentInfo := AgentInfo{
-		ID:       "elastic-agent-id",
-		Version:  packageVersion,
-		Snapshot: true,
+		ID:          "elastic-agent-id",
+		Version:     packageVersion,
+		Snapshot:    true,
+		ManagedMode: proto.AgentManagedMode_STANDALONE,
 	}
 	vInfo := VersionInfo{
 		Name:      "program",
@@ -185,6 +186,7 @@ func testClientV2CheckinInitial(t *testing.T, localRPC string, serverCreds, clie
 					Id:       wantAgentInfo.ID,
 					Version:  wantAgentInfo.Version,
 					Snapshot: wantAgentInfo.Snapshot,
+					Mode:     wantAgentInfo.ManagedMode,
 				},
 				Features: &proto.Features{
 					Fqdn: &proto.FQDNFeature{Enabled: wantFQDN},
@@ -303,8 +305,9 @@ func testClientV2CheckinInitial(t *testing.T, localRPC string, serverCreds, clie
 		assert.Equal(t, wantAgentInfo.ID, agentInfo.ID)
 		assert.Equal(t, wantAgentInfo.Version, agentInfo.Version)
 		assert.True(t, wantAgentInfo.Snapshot, agentInfo.Snapshot)
+		assert.Equal(t, wantAgentInfo.ManagedMode, agentInfo.ManagedMode)
 	}
-	
+
 	assert.Truef(t, gotFQDN, "FQND should be true")
 
 	if assert.Lenf(t, units, 2, "should have received 2 units") {

--- a/pkg/client/reader.go
+++ b/pkg/client/reader.go
@@ -76,9 +76,10 @@ func NewV2FromReader(reader io.Reader, ver VersionInfo, opts ...V2ClientOption) 
 
 	if info.AgentInfo != nil {
 		opts = append(opts, WithAgentInfo(AgentInfo{
-			ID:       info.AgentInfo.Id,
-			Version:  info.AgentInfo.Version,
-			Snapshot: info.AgentInfo.Snapshot,
+			ID:          info.AgentInfo.Id,
+			Version:     info.AgentInfo.Version,
+			Snapshot:    info.AgentInfo.Snapshot,
+			ManagedMode: info.AgentInfo.Mode,
 		}))
 	}
 


### PR DESCRIPTION
So, its been a while since I've tinkered with the agent client stuff, so when I did https://github.com/elastic/elastic-agent-client/pull/110 I forgot that I _also_ needed to change all the client helpers, and not just the GRPC. This also updates the client go code.