### PR TITLE
[npipe][fix] add a missing npipe import for windows

### DIFF
--- a/pkg/client/mock/npipe_windows.go
+++ b/pkg/client/mock/npipe_windows.go
@@ -7,7 +7,11 @@
 
 package mock
 
-import "net"
+import (
+	"net"
+
+	"github.com/elastic/elastic-agent-libs/api/npipe"
+)
 
 func newNPipeListener(name, sd string) (net.Listener, error) {
 	return npipe.NewListener(name, sd)


### PR DESCRIPTION
https://github.com/elastic/elastic-agent-client/pull/91 introduced `newNPipeListener` but didn't add the import.
    - I think it wants to use the `github.com/elastic/elastic-agent-libs/api/npipe` library. Correct me if I'm wrong @blakerouse / @aleksmaus
  
This PR adds the missing import.