### PR TITLE
fix: use proto.Equal to compare protobuf messages

### DIFF
--- a/pkg/client/unit.go
+++ b/pkg/client/unit.go
@@ -5,7 +5,6 @@
 package client
 
 import (
-	"reflect"
 	"sync"
 
 	gproto "google.golang.org/protobuf/proto"
@@ -206,7 +205,7 @@ func (u *Unit) UpdateState(state UnitState, message string, payload map[string]i
 	}
 	if (u.statePayload == nil && statePayload != nil) ||
 		(u.statePayload != nil && statePayload == nil) ||
-		!reflect.DeepEqual(u.statePayload, statePayload) {
+		!gproto.Equal(u.statePayload, statePayload) {
 		u.statePayload = statePayload
 		changed = true
 	}


### PR DESCRIPTION
replace reflect deepequal with proto.Equal

reflection is comparing some internal fields used during marshaling, causing race conditions in the beats reloader code.
the race condition causes APM Server tests to fail with the race detector enabled