### PR TITLE
Upgrading go version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-agent-client/v7
 
-go 1.24
+go 1.23
 
 require (
 	github.com/elastic/elastic-agent-libs v0.7.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-agent-client/v7
 
-go 1.21
+go 1.24
 
 require (
 	github.com/elastic/elastic-agent-libs v0.7.2


### PR DESCRIPTION
What it says on the tin.  Just a change in `go.mod`.